### PR TITLE
Update create & deploy script

### DIFF
--- a/bin/create.sh
+++ b/bin/create.sh
@@ -14,12 +14,15 @@ fi
 POOL_ID=$1
 TEMPLATE=$2
 
-# TODO: this should be loaded from the repo
-IPFS_HASH="QmUvZkxKFDyMAR5LmJjZC2ydhisGjrpCD2UbnUdJL6uD5t"
+RELEASES=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/centrifuge/tinlake-pools-mainnet/releases)
+IPFS=$(echo $RELEASES | jq -r ".[0].body" | awk '/https/{print $0}')
 
-POOLS_FILE=$(curl -s https://cloudflare-ipfs.com/ipfs/$IPFS_HASH)
+POOLS_FILE=$(curl -s $IPFS)
 NAME=$(echo $POOLS_FILE | jq -r ".[\"$POOL_ID\"].metadata.shortName")
 ADDRESSES=$(echo $POOLS_FILE | jq -r ".[\"$POOL_ID\"].addresses" | jq -r 'keys[] as $k | "\taddress constant public \($k) = \(.[$k]);"')
+
+mkdir './src/draft'
+touch './src/draft/addresses.sol'
 
 echo """
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-export ETH_GAS=10000000
-export GASNOW_PRICE_ESTIMATE="rapid"
-export ETH_GAS_PRICE=$(curl -s "https://www.gasnow.org/api/v3/gas/price?utm_source=tinlake-deploy" | jq -r ".data.$GASNOW_PRICE_ESTIMATE")
-
 echo "ETH_RPC_URL = $ETH_RPC_URL"
 echo "ETH_FROM = $ETH_FROM"
 echo "ETH_GAS_PRICE = $(printf %.0f $(echo "$ETH_GAS_PRICE/10^9" | bc -l)) gwei"


### PR DESCRIPTION
In this PR:

- Update the create script to grab the IPFS hash of the latest tinlake-pools-mainnet release
- Update the create script to make the /draft directory. Previously the script would only run when this directory was made manually
- Update the deploy script to just use environment variables for gas instead of trying to use the deprecated GASNOW api.